### PR TITLE
Changed so properties can be read from ember-data records

### DIFF
--- a/packages/ember-crossfilter/ember-crossfilter.js
+++ b/packages/ember-crossfilter/ember-crossfilter.js
@@ -562,7 +562,7 @@
                     configurable    : false,
                     writable        : false,
                     value           : this._crossfilter.dimension(function(d) {
-                        return d[property];
+                        return $ember.isNone( d[property] ) ? d.get(property) : d[property];
                     })
                 });
 
@@ -710,7 +710,7 @@
         _sortedContent: function _sortedContent(content, property, isAscending) {
 
             // Initialise the sorting using Crossfilter's `quicksort`.
-            var sortAlgorithm   = crossfilter.quicksort.by(function(d) { return d[property]; });
+            var sortAlgorithm   = crossfilter.quicksort.by(function(d) { return $ember.isNone( d[property] ) ? d.get(property) : d[property]; });
 
             // Sort the content using Crossfilter.
             var sorted = sortAlgorithm(content, 0, content.length);
@@ -858,5 +858,5 @@
         }
 
     });
-    
+
 })(window, window.Ember);

--- a/packages/ember-crossfilter/ember-crossfilter.js
+++ b/packages/ember-crossfilter/ember-crossfilter.js
@@ -562,9 +562,17 @@
                     configurable    : false,
                     writable        : false,
                     value           : this._crossfilter.dimension(function(d) {
-                        return $ember.isNone( d[property] ) ? d.get(property) : d[property];
-                    })
-                });
+                        if ($ember.isNone(d[property])){
+
+                            if (d.hasOwnProperty('get')) {
+                                return d.get(property);
+                            } else {
+                                return null;
+                            }
+                        }
+                        return d[property];
+                      })
+                    });
 
             };
 
@@ -710,7 +718,19 @@
         _sortedContent: function _sortedContent(content, property, isAscending) {
 
             // Initialise the sorting using Crossfilter's `quicksort`.
-            var sortAlgorithm   = crossfilter.quicksort.by(function(d) { return $ember.isNone( d[property] ) ? d.get(property) : d[property]; });
+            var sortAlgorithm   = crossfilter.quicksort.by(function(d) {
+                         if ($ember.isNone(d[property])){
+
+                            if (d.hasOwnProperty('get')) {
+                                return d.get(property);
+                            } else {
+                                return null;
+                            }
+                        }
+                        return d[property];
+              });
+
+
 
             // Sort the content using Crossfilter.
             var sorted = sortAlgorithm(content, 0, content.length);


### PR DESCRIPTION
In ember-data records are accessed via the get method.
If d[property] doesn't exist then d.get(property) will be called.
Reference: Issue #34
