### PR TITLE
Use Ember.get when accessing content.length

### DIFF
--- a/packages/ember-crossfilter/ember-crossfilter.js
+++ b/packages/ember-crossfilter/ember-crossfilter.js
@@ -733,7 +733,7 @@
 
 
             // Sort the content using Crossfilter.
-            var sorted = sortAlgorithm(content, 0, content.length);
+            var sorted = sortAlgorithm(content, 0, $ember.get(content, 'length'));
 
             if (!isAscending) {
                 // If we want it in descending order, then we need to reverse the array.

--- a/packages/ember-crossfilter/ember-crossfilter.js
+++ b/packages/ember-crossfilter/ember-crossfilter.js
@@ -430,7 +430,7 @@
 
             // Checks whether we have a defined controller, and/or no content.
             var hasDefinedCrossfilter   = !!this._crossfilter,
-                hasNoContent            = !content.length;
+                hasNoContent            = !$ember.get(this, 'content.length');
 
             // If we don't want have any content yet, or a defined Crossfilter, then either
             // the content hasn't been loaded yet, or we've already created the Crossfilter.


### PR DESCRIPTION
This fixes two place where the code was accessing `content.length` directly instead of using `Ember.get`, causing it to fail on ArrayProxy content.
