### PR TITLE
Replace `hasOwnProperty` with `in` to also detect prototype `get`

### DIFF
--- a/packages/ember-crossfilter/ember-crossfilter.js
+++ b/packages/ember-crossfilter/ember-crossfilter.js
@@ -564,7 +564,7 @@
                     value           : this._crossfilter.dimension(function(d) {
                         if ($ember.isNone(d[property])){
 
-                            if (d.hasOwnProperty('get')) {
+                            if ('get' in d) {
                                 return d.get(property);
                             } else {
                                 return null;
@@ -721,7 +721,7 @@
             var sortAlgorithm   = crossfilter.quicksort.by(function(d) {
                          if ($ember.isNone(d[property])){
 
-                            if (d.hasOwnProperty('get')) {
+                            if ('get' in d) {
                                 return d.get(property);
                             } else {
                                 return null;


### PR DESCRIPTION
In most (all?) cases, `get` is going to be inherited from Ember.Observable. It won't be detected with `hasOwnProperty`. This uses `'get' in` to get around that.
